### PR TITLE
Update selenium-standalone to v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "browserstacktunnel-wrapper": "^1.4.2",
     "gulp-util": "^3.0.7",
-    "selenium-standalone": "^5.0.0",
+    "selenium-standalone": "^6.0.1",
     "through2": "^0.6.5",
     "webdriverio": "^4.0.7"
   },


### PR DESCRIPTION
This version of selenium-standalone supports marionette by default. Marionette support is required for running firefox 48+